### PR TITLE
fix: Replace operation should edit values in place.

### DIFF
--- a/lib/src/operation.dart
+++ b/lib/src/operation.dart
@@ -117,7 +117,11 @@ class Replace implements Operation {
   final Object? value;
 
   @override
-  Object? apply(Object? document) => path.write(document, value);
+  Object? apply(Object? document) {
+    // Unlike `path.write`, `path.read` will throw if the path does not exist.
+    path.read(document);
+    return path.write(document, value);
+  }
 
   @override
   Map toJson() => {

--- a/lib/src/operation.dart
+++ b/lib/src/operation.dart
@@ -117,7 +117,7 @@ class Replace implements Operation {
   final Object? value;
 
   @override
-  Object? apply(Object? document) => path.add(path.remove(document), value);
+  Object? apply(Object? document) => path.write(document, value);
 
   @override
   Map toJson() => {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ description: JSON Patch (RFC 6902). Implements Add, Copy, Move, Remove, Replace,
 homepage: "https://github.com/f3ath/rfc-6902-dart"
 
 environment:
-  sdk: ">=3.2.0 <4.0.0"
+  sdk: '>=3.2.0 <4.0.0'
 
 dependencies:
   rfc_6901: ^0.2.0
@@ -17,5 +17,5 @@ dev_dependencies:
 
 cider:
   link_template:
-    tag: "https://github.com/f3ath/rfc-6902-dart/releases/tag/%tag%"
-    diff: "https://github.com/f3ath/rfc-6902-dart/compare/%from%...%to%"
+    tag: 'https://github.com/f3ath/rfc-6902-dart/releases/tag/%tag%'
+    diff: 'https://github.com/f3ath/rfc-6902-dart/compare/%from%...%to%'

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,6 +14,7 @@ dev_dependencies:
   test: ^1.21.1
   coverage: ^1.2.0
   check_coverage: ^0.0.4
+  checks: ^0.3.0
 
 cider:
   link_template:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ description: JSON Patch (RFC 6902). Implements Add, Copy, Move, Remove, Replace,
 homepage: "https://github.com/f3ath/rfc-6902-dart"
 
 environment:
-  sdk: '>=3.2.0 <4.0.0'
+  sdk: ">=3.2.0 <4.0.0"
 
 dependencies:
   rfc_6901: ^0.2.0
@@ -14,9 +14,8 @@ dev_dependencies:
   test: ^1.21.1
   coverage: ^1.2.0
   check_coverage: ^0.0.4
-  checks: ^0.3.0
 
 cider:
   link_template:
-    tag: 'https://github.com/f3ath/rfc-6902-dart/releases/tag/%tag%'
-    diff: 'https://github.com/f3ath/rfc-6902-dart/compare/%from%...%to%'
+    tag: "https://github.com/f3ath/rfc-6902-dart/releases/tag/%tag%"
+    diff: "https://github.com/f3ath/rfc-6902-dart/compare/%from%...%to%"

--- a/test/order_preservation_test.dart
+++ b/test/order_preservation_test.dart
@@ -1,4 +1,3 @@
-import 'package:checks/checks.dart';
 import 'package:rfc_6901/rfc_6901.dart';
 import 'package:rfc_6902/rfc_6902.dart';
 import 'package:test/test.dart';
@@ -7,15 +6,11 @@ void main() {
   group('Order Preservation', () {
     test('Map key order is preserved after replace operation', () {
       final map = {'a': 1, 'b': 2, 'c': 3};
-      final expected = {'a': 4, 'b': 2, 'c': 3};
 
       final replaceOp = Replace(JsonPointer('/a'), 4);
       final patch = JsonPatch.build([replaceOp]);
-      final result = patch.applyTo(map);
-
-      check(result).isA<Map>().which((result) {
-        return result.keys.containsInOrder(expected.keys);
-      });
+      final result = patch.applyTo(map) as Map;
+      expect(result.keys.toList(), equals(['a', 'b', 'c']));
     });
   });
 }

--- a/test/order_preservation_test.dart
+++ b/test/order_preservation_test.dart
@@ -1,0 +1,21 @@
+import 'package:checks/checks.dart';
+import 'package:rfc_6901/rfc_6901.dart';
+import 'package:rfc_6902/rfc_6902.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('Order Preservation', () {
+    test('Map key order is preserved after replace operation', () {
+      final map = {'a': 1, 'b': 2, 'c': 3};
+      final expected = {'a': 4, 'b': 2, 'c': 3};
+
+      final replaceOp = Replace(JsonPointer('/a'), 4);
+      final patch = JsonPatch.build([replaceOp]);
+      final result = patch.applyTo(map);
+
+      check(result).isA<Map>().which((result) {
+        return result.keys.containsInOrder(expected.keys);
+      });
+    });
+  });
+}


### PR DESCRIPTION
Given a set of properties of a map:

```json
{
  "foo": 1,
  "bar": 2,
}
```

A replace operation on `foo` would result in the order of the properties being switched after the edit is applied, which is undesired behavior. The property should instead be updated "in-place", i.e. so that the order is not changed. This PR makes that change.